### PR TITLE
Fix sticker navigation to park detail pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -1135,13 +1135,27 @@ class ParkPassportFinder {
                 <div class="sticker-browse-info">
                     <h4>${sticker.park}</h4>
                     <p class="sticker-browse-type">${sticker.type === 'junior-ranger' ? 'Junior Ranger' : 'Regular'}</p>
-                    <a href="${sticker.purchaseUrl}" target="_blank" rel="noopener" class="stamp-link">Buy Sticker</a>
+                    <a href="${sticker.purchaseUrl}" target="_blank" rel="noopener" class="stamp-link" onclick="event.stopPropagation()">Buy Sticker</a>
                 </div>
             `;
 
             item.addEventListener('click', (e) => {
                 if (!e.target.closest('a')) {
-                    this.navigateTo(`park/${encodeURIComponent(sticker.park)}`);
+                    // Try to find the park in stamp data - handle name mismatches
+                    let parkFound = false;
+                    this.data.forEach(yearData => {
+                        yearData.stamps.forEach(stamp => {
+                            if (stamp.park === sticker.park || normalizeParkName(stamp.park) === sticker.park) {
+                                this.navigateTo(`park/${encodeURIComponent(stamp.park)}`);
+                                parkFound = true;
+                            }
+                        });
+                    });
+                    
+                    // If not found in stamp data, navigate with the sticker park name
+                    if (!parkFound) {
+                        this.navigateTo(`park/${encodeURIComponent(sticker.park)}`);
+                    }
                 }
             });
 
@@ -1197,13 +1211,27 @@ class ParkPassportFinder {
                 <div class="sticker-browse-info">
                     <h4>${sticker.park}</h4>
                     <p class="sticker-browse-type">Junior Ranger</p>
-                    <a href="${sticker.purchaseUrl}" target="_blank" rel="noopener" class="stamp-link">Buy Jr. Ranger</a>
+                    <a href="${sticker.purchaseUrl}" target="_blank" rel="noopener" class="stamp-link" onclick="event.stopPropagation()">Buy Jr. Ranger</a>
                 </div>
             `;
 
             item.addEventListener('click', (e) => {
                 if (!e.target.closest('a')) {
-                    this.navigateTo(`park/${encodeURIComponent(sticker.park)}`);
+                    // Try to find the park in stamp data - handle name mismatches
+                    let parkFound = false;
+                    this.data.forEach(yearData => {
+                        yearData.stamps.forEach(stamp => {
+                            if (stamp.park === sticker.park || normalizeParkName(stamp.park) === sticker.park) {
+                                this.navigateTo(`park/${encodeURIComponent(stamp.park)}`);
+                                parkFound = true;
+                            }
+                        });
+                    });
+                    
+                    // If not found in stamp data, navigate with the sticker park name
+                    if (!parkFound) {
+                        this.navigateTo(`park/${encodeURIComponent(sticker.park)}`);
+                    }
                 }
             });
 

--- a/app.js
+++ b/app.js
@@ -1330,6 +1330,9 @@ document.addEventListener('DOMContentLoaded', () => {
         removeAllImageListeners('.stamp-set-image-large img');
         removeAllImageListeners('.appearance-image img');
         removeAllImageListeners('.timeline-image-container img');
+        removeAllImageListeners('.sticker-browse-image img');
+        removeAllImageListeners('.sticker-image');
+        
         // Year detail view
         document.querySelectorAll('.stamp-set-image-large img').forEach(img => {
             img.style.cursor = 'zoom-in';
@@ -1357,6 +1360,26 @@ document.addEventListener('DOMContentLoaded', () => {
                 e.stopPropagation();
                 e.preventDefault();
                 console.log('[DEBUG] Timeline image clicked:', img.src);
+                openModal(img.src, img.alt);
+            });
+        });
+        // Individual stickers browse view
+        document.querySelectorAll('.sticker-browse-image img').forEach(img => {
+            img.style.cursor = 'zoom-in';
+            img.addEventListener('click', function(e) {
+                e.stopPropagation();
+                e.preventDefault();
+                console.log('[DEBUG] Individual sticker image clicked:', img.src);
+                openModal(img.src, img.alt);
+            });
+        });
+        // Park detail individual stickers
+        document.querySelectorAll('.sticker-image').forEach(img => {
+            img.style.cursor = 'zoom-in';
+            img.addEventListener('click', function(e) {
+                e.stopPropagation();
+                e.preventDefault();
+                console.log('[DEBUG] Park detail sticker image clicked:', img.src);
                 openModal(img.src, img.alt);
             });
         });

--- a/styles.css
+++ b/styles.css
@@ -1626,4 +1626,24 @@ footer a:hover {
 .stamp-content .park-stickers {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
+}
+
+/* Make individual sticker browse items clearly clickable */
+.individual-sticker-browse-item {
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.individual-sticker-browse-item:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-hover);
+}
+
+.individual-sticker-browse-item .sticker-browse-info h4 {
+    color: var(--primary-green);
+    transition: color 0.2s ease;
+}
+
+.individual-sticker-browse-item:hover .sticker-browse-info h4 {
+    color: var(--accent-green);
 } 

--- a/styles.css
+++ b/styles.css
@@ -952,6 +952,11 @@ footer a:hover {
     height: 100%;
     object-fit: cover;
     border-radius: var(--radius);
+    transition: var(--transition);
+}
+
+.sticker-image:hover {
+    transform: scale(1.05);
 }
 
 .sticker-placeholder {
@@ -1548,6 +1553,11 @@ footer a:hover {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    transition: var(--transition);
+}
+
+.sticker-browse-image img:hover {
+    transform: scale(1.05);
 }
 
 .sticker-browse-info {


### PR DESCRIPTION
## Summary
- Fixed click handlers in individual stickers and junior ranger views to properly navigate to park landing pages
- Added park name normalization to handle mismatches between sticker mapping and stamp data  
- Enhanced CSS to make sticker cards clearly clickable with hover effects

## Test plan
- [x] Click on individual sticker cards and verify navigation to park detail pages
- [x] Click on junior ranger sticker cards and verify navigation to park detail pages  
- [x] Verify purchase links still open in new tabs without triggering navigation
- [x] Test hover effects show cards are clickable