### PR TITLE
feat: Add dark mode toggle functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,59 @@
 console.log('[DEBUG] app.js loaded');
 
+// Theme Management System
+class ThemeManager {
+    constructor() {
+        this.init();
+    }
+
+    init() {
+        this.loadTheme();
+        this.setupThemeToggle();
+        // Remove preload class to enable transitions
+        setTimeout(() => {
+            document.body.classList.remove('preload');
+        }, 100);
+    }
+
+    loadTheme() {
+        // Check localStorage first, then system preference
+        const savedTheme = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme = savedTheme || (prefersDark ? 'dark' : 'light');
+        
+        this.setTheme(theme);
+    }
+
+    setTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        
+        // Update button state
+        const toggle = document.getElementById('themeToggle');
+        if (toggle) {
+            toggle.setAttribute('aria-label', 
+                theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+            );
+        }
+    }
+
+    toggleTheme() {
+        const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        this.setTheme(newTheme);
+    }
+
+    setupThemeToggle() {
+        const toggle = document.getElementById('themeToggle');
+        if (toggle) {
+            toggle.addEventListener('click', () => this.toggleTheme());
+        }
+    }
+}
+
+// Initialize theme manager
+const themeManager = new ThemeManager();
+
 // Helper function to normalize park names for sticker mapping lookup
 function normalizeParkName(parkName) {
     // Handle specific special cases first

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="styles.css">
     <meta name="description" content="Find which Passport To Your National Parks® stamp set contains your favorite park. Search by park name, year, or region.">
 </head>
-<body>
+<body class="preload">
     <header>
         <div class="container">
             <h1><a href="#" style="color: white; text-decoration: none;">Park Passport Finder</a></h1>
@@ -15,6 +15,11 @@
             <nav class="header-nav">
                 <a href="#series" data-route="series">Series Overview</a>
                 <a href="#" data-route="">Browse All</a>
+                <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
+                    <div class="theme-toggle-track">
+                        <div class="theme-toggle-thumb"></div>
+                    </div>
+                </button>
             </nav>
         </div>
     </header>

--- a/styles.css
+++ b/styles.css
@@ -102,6 +102,45 @@
     --breakpoint-2xl: 1536px;
 }
 
+/* Dark Mode Theme Variables */
+[data-theme="dark"] {
+    /* Core Colors - Dark Mode */
+    --primary-green: #6fa343;
+    --light-green: #8bc34a;
+    --accent-green: #9ccc65;
+    --accent-color: #9ccc65;
+    --accent-color-dark: #6fa343;
+    
+    /* Background Colors - Dark Mode */
+    --bg-light: #1a1a1a;
+    --bg-dark: #0d0d0d;
+    --bg-white: #141414;
+    --bg-overlay: rgba(0, 0, 0, 0.95);
+    --bg-overlay-light: rgba(20, 20, 20, 0.95);
+    
+    /* Text Colors - Dark Mode */
+    --text-dark: #e4e4e4;
+    --text-gray: #a0a0a0;
+    --text-secondary: #b0b0b0;
+    --text-light: #f0f0f0;
+    --text-muted: #808080;
+    
+    /* Border Colors - Dark Mode */
+    --border-color: #2a2a2a;
+    --border-light: rgba(255, 255, 255, 0.05);
+    --border-dark: rgba(255, 255, 255, 0.1);
+    
+    /* Shadows - Dark Mode */
+    --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+    --shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.6);
+    --shadow-xl: 0 12px 24px rgba(0, 0, 0, 0.7);
+    --shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.6);
+    --shadow-glow: 0 0 20px rgba(156, 204, 101, 0.3);
+}
+
 /* Animation Keyframes Library */
 @keyframes fadeIn {
     from { opacity: 0; }
@@ -1859,4 +1898,74 @@ footer a:hover {
 
 .individual-sticker-browse-item:hover .sticker-browse-info h4 {
     color: var(--accent-green);
-} 
+}
+
+/* Theme Toggle Button */
+.theme-toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    background: var(--bg-white);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-full);
+    padding: var(--space-xs);
+    cursor: pointer;
+    transition: var(--transition-color);
+    margin-left: var(--space-md);
+    width: 48px;
+    height: 24px;
+    box-shadow: var(--shadow-sm);
+}
+
+.theme-toggle:hover {
+    box-shadow: var(--shadow-md);
+}
+
+.theme-toggle-track {
+    position: relative;
+    width: 40px;
+    height: 20px;
+    border-radius: var(--radius-full);
+    background: var(--bg-light);
+    transition: var(--transition);
+}
+
+.theme-toggle-thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent-color);
+    transition: var(--transition-transform);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 8px;
+    color: white;
+}
+
+[data-theme="dark"] .theme-toggle-thumb {
+    transform: translateX(20px);
+}
+
+.theme-toggle-thumb::before {
+    content: "☀️";
+}
+
+[data-theme="dark"] .theme-toggle-thumb::before {
+    content: "🌙";
+}
+
+/* Smooth theme transitions */
+* {
+    transition: background-color var(--duration-normal) ease,
+                color var(--duration-normal) ease,
+                border-color var(--duration-normal) ease;
+}
+
+/* Prevent transition on initial load */
+.preload * {
+    transition: none !important;
+}


### PR DESCRIPTION
## Summary
Adds Netflix-style dark mode with smooth theme switching and localStorage persistence.

## Changes
- **Dark Mode CSS**: Comprehensive dark theme variables with enhanced shadows
- **Toggle Button**: Animated sun/moon toggle in header navigation  
- **JavaScript**: Theme management with localStorage and system preference detection
- **Transitions**: Smooth color transitions with preload flash prevention
- **Accessibility**: Proper ARIA labels and keyboard support

## Features
- 🌙 **Smart Detection**: Auto-detects system dark mode preference
- 💾 **Persistence**: Remembers theme choice across browser sessions
- ⚡ **Smooth Transitions**: No flash of unstyled content
- 🎨 **Netflix-Inspired**: Dark theme with enhanced contrast and shadows
- ♿ **Accessible**: Full keyboard and screen reader support

## Test Plan
- [x] Toggle works smoothly between light and dark themes
- [x] Theme persists after page refresh
- [x] Respects system preference on first visit
- [x] No flash of unstyled content on load
- [x] Accessible with keyboard navigation
- [x] All pages maintain proper contrast in both themes

Try it out: Toggle the sun/moon button in the header\! 🌓