### PR TITLE
fix: Hide hero carousel on detail views

### DIFF
--- a/app.js
+++ b/app.js
@@ -1039,12 +1039,18 @@ class ParkPassportFinder {
         const hash = window.location.hash.slice(1);
         const [type, ...params] = hash.split('/');
         
+        // Show/hide hero carousel based on route
+        const heroSection = document.getElementById('heroSection');
+        if (heroSection) {
+            heroSection.style.display = !type ? 'block' : 'none';
+        }
+        
         // Hide all sections first
         const sections = ['searchSection', 'browseSection', 'resultsSection', 'detailSection'];
         sections.forEach(id => document.getElementById(id).style.display = 'none');
         
         if (!type) {
-            // Default view - show main sections
+            // Default view - show main sections and hero carousel
             sections.slice(0, 3).forEach(id => document.getElementById(id).style.display = 'block');
             this.showBrowseView('timeline');
             return;


### PR DESCRIPTION
## Summary
- Modified handleRoute() to show carousel only on main page
- Carousel now hidden when navigating to parks or collections 
- Improved navigation experience with contextual content display

## Test plan
- [x] Carousel visible on main page
- [x] Carousel hidden when clicking into park details
- [x] Carousel reappears when navigating back to home